### PR TITLE
HAF hotfix: prevent duplicate paid orders by transaction id

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -577,8 +577,31 @@ class OrdersController < ApplicationController
       end
     end
 
+    # Idempotency guard: if an order already exists for this restaurant+transaction_id,
+    # return it instead of creating a duplicate.
+    transaction_id = new_params[:transaction_id].presence
+    if transaction_id.present?
+      existing_order = Order.find_by(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
+      if existing_order.present?
+        Rails.logger.warn("Idempotency hit: returning existing order #{existing_order.id} for transaction_id #{transaction_id}")
+        return render json: existing_order, status: :ok
+      end
+    end
+
     # Create the order using OrderService for proper tenant isolation
-    @order = order_service.create_order(new_params)
+    begin
+      @order = order_service.create_order(new_params)
+    rescue ActiveRecord::RecordNotUnique
+      if transaction_id.present?
+        existing_order = Order.find_by(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
+        if existing_order.present?
+          Rails.logger.warn("Idempotency race hit: returning existing order #{existing_order.id} for transaction_id #{transaction_id}")
+          return render json: existing_order, status: :ok
+        end
+      end
+      raise
+    end
+
     @order.status = "pending"
     # The staff_created flag will be set automatically by the before_create callback
     # based on the staff_modal virtual attribute

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -602,7 +602,11 @@ class OrdersController < ApplicationController
           Rails.logger.warn("Idempotency race hit: returning existing order #{existing_order.id} for transaction_id #{transaction_id}")
           return render json: existing_order, status: :ok
         end
+
+        Rails.logger.error("RecordNotUnique for transaction_id #{transaction_id} but no non-canceled/refunded order found")
+        return render json: { error: "Duplicate transaction detected. Please contact support." }, status: :conflict
       end
+
       raise
     end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -581,7 +581,9 @@ class OrdersController < ApplicationController
     # return it instead of creating a duplicate.
     transaction_id = new_params[:transaction_id].presence
     if transaction_id.present?
-      existing_order = Order.find_by(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
+      existing_order = Order.where(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
+                           .where.not(payment_status: ["canceled", "refunded"])
+                           .first
       if existing_order.present?
         Rails.logger.warn("Idempotency hit: returning existing order #{existing_order.id} for transaction_id #{transaction_id}")
         return render json: existing_order, status: :ok
@@ -593,7 +595,9 @@ class OrdersController < ApplicationController
       @order = order_service.create_order(new_params)
     rescue ActiveRecord::RecordNotUnique
       if transaction_id.present?
-        existing_order = Order.find_by(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
+        existing_order = Order.where(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
+                             .where.not(payment_status: ["canceled", "refunded"])
+                             .first
         if existing_order.present?
           Rails.logger.warn("Idempotency race hit: returning existing order #{existing_order.id} for transaction_id #{transaction_id}")
           return render json: existing_order, status: :ok

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -593,8 +593,9 @@ class OrdersController < ApplicationController
     # Create the order using OrderService for proper tenant isolation
     begin
       @order = order_service.create_order(new_params)
-    rescue ActiveRecord::RecordNotUnique
-      if transaction_id.present?
+    rescue ActiveRecord::RecordNotUnique => e
+      idempotency_index = "idx_orders_unique_restaurant_transaction_id_real"
+      if transaction_id.present? && e.message.include?(idempotency_index)
         existing_order = Order.where(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
                              .where.not(payment_status: ["canceled", "refunded"])
                              .first
@@ -603,7 +604,7 @@ class OrdersController < ApplicationController
           return render json: existing_order, status: :ok
         end
 
-        Rails.logger.error("RecordNotUnique for transaction_id #{transaction_id} but no non-canceled/refunded order found")
+        Rails.logger.error("RecordNotUnique on #{idempotency_index} for transaction_id #{transaction_id} but no non-canceled/refunded order found")
         return render json: { error: "Duplicate transaction detected. Please contact support." }, status: :conflict
       end
 

--- a/db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb
+++ b/db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb
@@ -1,0 +1,16 @@
+class AddUniqueIndexOnOrdersRestaurantTransactionId < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    add_index :orders,
+              [ :restaurant_id, :transaction_id ],
+              unique: true,
+              where: "transaction_id IS NOT NULL AND transaction_id <> '' AND transaction_id NOT LIKE 'TEST-%' AND payment_status NOT IN ('canceled','refunded')",
+              algorithm: :concurrently,
+              name: "idx_orders_unique_restaurant_transaction_id_real"
+  end
+
+  def down
+    remove_index :orders, name: "idx_orders_unique_restaurant_transaction_id_real", algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
## Summary
Prevents duplicate paid orders from being created for the same payment transaction.

## Changes
- Added idempotency guard in `OrdersController#create`:
  - if an order already exists for `(restaurant_id, transaction_id)`, return existing order (`200`) instead of creating a duplicate.
  - handles race condition by rescuing `ActiveRecord::RecordNotUnique` and returning existing order.
- Added partial unique DB index:
  - `orders(restaurant_id, transaction_id)` unique
  - applies only for real transactions (non-null/non-empty, not `TEST-%`, not canceled/refunded historical rows).

## Why
In production incident, multiple order rows were created for the same payment intent under retry/duplicate-submission conditions.

## Notes
- This intentionally preserves historical duplicate rows that were already canceled/refunded by excluding those statuses from the uniqueness predicate.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix prevents duplicate paid orders from being created for the same payment transaction by adding a two-layer idempotency guard in `OrdersController#create` and a partial unique DB index on `(restaurant_id, transaction_id)`.

- **Application-level pre-check** (lines 580–591): Before attempting order creation, queries for an existing non-canceled/non-refunded order with the same `restaurant_id + transaction_id`. Returns the existing order with `200 OK` if found, avoiding a duplicate write entirely.
- **Race-condition rescue** (lines 594–612): Wraps `order_service.create_order` in a `rescue ActiveRecord::RecordNotUnique` block. Critically, the rescue first verifies the constraint name matches the new idempotency index (via `e.message.include?(idempotency_index)`) before acting, so other unique constraint violations (e.g. `order_number`) still re-raise. If the idempotency index fires but no matching live order is found (edge case: order canceled/refunded in the narrow race window), it now returns `409 Conflict` instead of propagating an unhandled 500.
- **Partial unique DB index**: The migration (`20260306073500`) adds `idx_orders_unique_restaurant_transaction_id_real` with a `WHERE` clause that excludes `NULL`/empty `transaction_id`, `TEST-%` prefixes, and `canceled`/`refunded` statuses. The `CONCURRENTLY` algorithm and `disable_ddl_transaction!` are correct for zero-downtime deployment.
- **Minor inconsistency**: The application-level pre-check does not exclude `TEST-%` transaction IDs, while the DB index does. In practice this is harmless (test mode always generates fresh random IDs), but the two layers are slightly out of sync. See the inline comment for a suggested fix.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it addresses a real production incident with a well-structured fix and the previously identified critical issues have been resolved.
- The DB migration is clean and uses the correct CONCURRENTLY/disable_ddl_transaction! pattern. The controller guard correctly mirrors the index predicate (excluding canceled/refunded orders) and scopes the RecordNotUnique rescue to the specific index name rather than swallowing all constraint violations. The only remaining gap is a minor inconsistency where the application pre-check does not exclude TEST-prefixed transaction IDs the way the DB index does, which has no practical impact under normal operation.
- No files require special attention beyond the minor TEST-% inconsistency in the pre-check at app/controllers/orders_controller.rb:582.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/orders_controller.rb | Adds a two-layer idempotency guard (pre-check + RecordNotUnique rescue) scoped to non-canceled/refunded orders. Previous thread concerns about stale status matching and unhandled 500 errors have been addressed; minor inconsistency remains between the application-level guard and the DB index for TEST-prefixed transaction IDs. |
| db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb | Adds a partial unique index on (restaurant_id, transaction_id) using CONCURRENTLY for zero-downtime deployment. The WHERE predicate correctly excludes NULL/empty values, TEST-prefixed IDs, and canceled/refunded rows. disable_ddl_transaction! is properly set. No issues found. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /orders] --> B{Test mode?}
    B -- Yes --> C[Generate TEST-xxxxxxxx transaction_id]
    B -- No --> D{transaction_id present?}
    D -- No --> E[422 Payment required]
    D -- Yes --> F[Build new_params]
    C --> F
    F --> G{transaction_id present\nin new_params?}
    G -- No --> H[Skip idempotency guard]
    G -- Yes --> I[Query: orders WHERE\nrestaurant_id + transaction_id\nAND payment_status NOT IN\ncanceled/refunded]
    I -- Found --> J[Return existing order\n200 OK]
    I -- Not found --> H
    H --> K[order_service.create_order]
    K -- Success --> L[Post-create processing\nInventory / Notifications]
    L --> M[201 Created]
    K -- RecordNotUnique --> N{e.message includes\nidempotency index name?}
    N -- No --> O[re-raise exception]
    N -- Yes --> P[Query: orders WHERE\nrestaurant_id + transaction_id\nAND payment_status NOT IN\ncanceled/refunded]
    P -- Found --> Q[Return existing order\n200 OK]
    P -- Not found --> R[409 Conflict\nDuplicate transaction detected]
```

<sub>Last reviewed commit: 9f76290</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->