### PR TITLE
HAF hotfix follow-up: scope transaction uniqueness to Stripe PI IDs

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -580,7 +580,7 @@ class OrdersController < ApplicationController
     # Idempotency guard: if an order already exists for this restaurant+transaction_id,
     # return it instead of creating a duplicate.
     transaction_id = new_params[:transaction_id].presence
-    if transaction_id.present?
+    if transaction_id.present? && transaction_id.start_with?("pi_")
       existing_order = Order.where(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
                            .where.not(payment_status: ["canceled", "refunded"])
                            .first
@@ -595,7 +595,7 @@ class OrdersController < ApplicationController
       @order = order_service.create_order(new_params)
     rescue ActiveRecord::RecordNotUnique => e
       idempotency_index = "idx_orders_unique_restaurant_transaction_id_real"
-      if transaction_id.present? && e.message.include?(idempotency_index)
+      if transaction_id.present? && transaction_id.start_with?("pi_") && e.message.include?(idempotency_index)
         existing_order = Order.where(restaurant_id: new_params[:restaurant_id], transaction_id: transaction_id)
                              .where.not(payment_status: ["canceled", "refunded"])
                              .first

--- a/db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb
+++ b/db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb
@@ -5,7 +5,7 @@ class AddUniqueIndexOnOrdersRestaurantTransactionId < ActiveRecord::Migration[7.
     add_index :orders,
               [ :restaurant_id, :transaction_id ],
               unique: true,
-              where: "transaction_id IS NOT NULL AND transaction_id <> '' AND transaction_id NOT LIKE 'TEST-%' AND payment_status NOT IN ('canceled','refunded')",
+              where: "transaction_id LIKE 'pi_%' AND payment_status NOT IN ('canceled','refunded')", 
               algorithm: :concurrently,
               name: "idx_orders_unique_restaurant_transaction_id_real"
   end

--- a/db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb
+++ b/db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb
@@ -5,7 +5,7 @@ class AddUniqueIndexOnOrdersRestaurantTransactionId < ActiveRecord::Migration[7.
     add_index :orders,
               [ :restaurant_id, :transaction_id ],
               unique: true,
-              where: "transaction_id LIKE 'pi_%' AND payment_status NOT IN ('canceled','refunded')", 
+              where: "transaction_id LIKE 'pi_%' AND payment_status NOT IN ('canceled','refunded')",
               algorithm: :concurrently,
               name: "idx_orders_unique_restaurant_transaction_id_real"
   end


### PR DESCRIPTION
## Why
PR #100 was merged and deploy failed on migration due to historical duplicate `transaction_id` values stored as Stripe receipt URLs (not payment intent IDs).

## What this follow-up changes
- Narrows unique index predicate to real Stripe PaymentIntent ids only:
  - `transaction_id LIKE 'pi_%'`
  - excludes canceled/refunded rows
- Aligns controller idempotency guard to same scope (`transaction_id.start_with?('pi_')`).

## Result
- Migration no longer fails on legacy duplicate receipt-URL rows.
- Duplicate protection remains active for real Stripe payment intents.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix follow-up correctly narrows the partial unique index on `orders(restaurant_id, transaction_id)` to scope protection to real Stripe PaymentIntent IDs (`LIKE 'pi_%'`), excluding legacy receipt-URL values that caused PR #100 to fail.

**Verified changes:**
- Migration's `WHERE` clause now uses a positive prefix match (`transaction_id LIKE 'pi_%' AND payment_status NOT IN ('canceled','refunded')`) to target only Stripe payment intents
- Both pre-creation and race-condition idempotency checks in `orders_controller.rb` (lines 583 and 598) gate on `transaction_id.start_with?("pi_")`, keeping application-layer logic consistent with the database constraint
- Controller queries correctly exclude canceled/refunded orders to align with the index predicate

The logic changes are sound and well-aligned between the database constraint and application-layer guards.

<h3>Confidence Score: 4/5</h3>

- Safe to merge: the logic changes are correct and well-aligned between database and application layers.
- The migration's narrowed index predicate and the controller's idempotency checks are correctly aligned to scope protection to real Stripe PaymentIntent IDs. Code changes are logically sound, with proper exclusion of canceled/refunded orders and consistent use of the `pi_` prefix guard. No logic errors or security issues detected. The scope is intentionally narrowed per the PR's stated goal of fixing the duplicate legacy receipt-URL problem.
- No files require special attention.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant OrdersController
    participant DB as PostgreSQL

    Client->>OrdersController: POST /orders (transaction_id: "pi_xxx")
    OrdersController->>OrdersController: start_with?("pi_") → true
    OrdersController->>DB: SELECT WHERE restaurant_id=X AND transaction_id="pi_xxx"<br/>AND payment_status NOT IN ('canceled','refunded')
    alt Existing order found (idempotency hit)
        DB-->>OrdersController: existing order
        OrdersController-->>Client: 200 OK (existing order)
    else No existing order
        OrdersController->>DB: INSERT order
        alt INSERT succeeds
            DB-->>OrdersController: new order
            OrdersController-->>Client: 201 Created
        else RecordNotUnique (race condition)
            DB-->>OrdersController: PG::UniqueViolation (idx_orders_unique_restaurant_transaction_id_real)
            OrdersController->>DB: SELECT WHERE restaurant_id=X AND transaction_id="pi_xxx"<br/>AND payment_status NOT IN ('canceled','refunded')
            alt Existing order found
                DB-->>OrdersController: existing order
                OrdersController-->>Client: 200 OK (existing order)
            else No order found (was canceled/refunded)
                OrdersController-->>Client: 409 Conflict
            end
        end
    end

    Note over Client,DB: Non-pi_ transaction IDs bypass all idempotency checks (by design)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb`, line 4-11 ([link](https://github.com/shimizu-technology/shimizu-order-suite/blob/979872c41ad9bf83daec438f283d4bd20d87a9e6/db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb#L4-L11)) 

   When `CREATE UNIQUE INDEX CONCURRENTLY` fails (as described in the PR description), PostgreSQL does **not** clean up automatically — it leaves behind an index marked as `INVALID`. If such an invalid index already exists under the name `idx_orders_unique_restaurant_transaction_id_real`, re-running this migration will raise `index "idx_orders_unique_restaurant_transaction_id_real" already exists` and abort before the new (correct) predicate is applied.

   A defensive approach is to explicitly drop the potentially-invalid index before recreating it:

   

   Since `disable_ddl_transaction!` is already set, `CONCURRENTLY` is allowed and won't conflict with the surrounding migration transaction.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: db/migrate/20260306073500_add_unique_index_on_orders_restaurant_transaction_id.rb
   Line: 4-11

   Comment:
   When `CREATE UNIQUE INDEX CONCURRENTLY` fails (as described in the PR description), PostgreSQL does **not** clean up automatically — it leaves behind an index marked as `INVALID`. If such an invalid index already exists under the name `idx_orders_unique_restaurant_transaction_id_real`, re-running this migration will raise `index "idx_orders_unique_restaurant_transaction_id_real" already exists` and abort before the new (correct) predicate is applied.

   A defensive approach is to explicitly drop the potentially-invalid index before recreating it:

   

   Since `disable_ddl_transaction!` is already set, `CONCURRENTLY` is allowed and won't conflict with the surrounding migration transaction.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 1bdb04f</sub>

<!-- /greptile_comment -->